### PR TITLE
fix: Remove Deface initializer

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -50,7 +50,7 @@ jobs:
           SIMPLECOV: 0
           CODECOV: 0
 
-      - uses: actions/upload-artifact@v2-preview
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
           SIMPLECOV: 1
           CODECOV: 1
 
-      - uses: actions/upload-artifact@v2-preview
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: screenshots

--- a/decidim-gallery.gemspec
+++ b/decidim-gallery.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "decidim-admin", ">= 0.26.0", "< 0.28.0"
   s.add_dependency "decidim-core", ">= 0.26.0", "< 0.28.0"
-  s.add_dependency "deface", "~> 1.9"
   s.add_development_dependency "decidim-participatory_processes", ">= 0.26.0", "< 0.28.0"
   s.metadata["rubygems_mfa_required"] = "true"
 end

--- a/decidim-gallery.gemspec
+++ b/decidim-gallery.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency "decidim-admin", ">= 0.26.0", "< 0.28.0"
   s.add_dependency "decidim-core", ">= 0.26.0", "< 0.28.0"
   s.add_dependency "deface", "~> 1.9"
+  s.add_dependency "nokogiri"
   s.add_development_dependency "decidim-participatory_processes", ">= 0.26.0", "< 0.28.0"
   s.metadata["rubygems_mfa_required"] = "true"
 end

--- a/decidim-gallery.gemspec
+++ b/decidim-gallery.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
   s.add_dependency "decidim-admin", ">= 0.26.0", "< 0.28.0"
   s.add_dependency "decidim-core", ">= 0.26.0", "< 0.28.0"
   s.add_dependency "deface", "~> 1.9"
-  s.add_dependency "nokogiri"
   s.add_development_dependency "decidim-participatory_processes", ">= 0.26.0", "< 0.28.0"
   s.metadata["rubygems_mfa_required"] = "true"
 end

--- a/lib/decidim/gallery.rb
+++ b/lib/decidim/gallery.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "deface"
 require "decidim/gallery/admin"
 require "decidim/gallery/engine"
 require "decidim/gallery/admin_engine"

--- a/lib/decidim/gallery/engine.rb
+++ b/lib/decidim/gallery/engine.rb
@@ -15,11 +15,11 @@ module Decidim
         root to: "gallery#index"
       end
 
-      #initializer "decidim_gallery.deface" do
+      # initializer "decidim_gallery.deface" do
       #  Rails.application.configure do
       #    config.deface.enabled = true
       #  end
-      #end
+      # end
 
       initializer "decidim_gallery.webpacker.assets_path" do
         Decidim.register_assets_path File.expand_path("app/packs", root)
@@ -33,11 +33,14 @@ module Decidim
       initializer "decidim_gallery.action_controller" do
         Rails.application.reloader.to_prepare do
           ActiveSupport.on_load :action_controller do
-            ::Decidim::Admin::StaticPagesController.helper Decidim::Gallery::Admin::ApplicationHelper
             ::Decidim::Admin::StaticPageForm.prepend Decidim::Gallery::Admin::StaticPages::Form
             ::Decidim::Admin::CreateStaticPage.prepend Decidim::Gallery::Admin::StaticPages::Command
             ::Decidim::Admin::UpdateStaticPage.prepend Decidim::Gallery::Admin::StaticPages::Command
           end
+        end
+
+        config.after_initialize do
+          ::Decidim::Admin::StaticPagesController.helper Decidim::Gallery::Admin::ApplicationHelper
         end
       end
 

--- a/lib/decidim/gallery/engine.rb
+++ b/lib/decidim/gallery/engine.rb
@@ -2,6 +2,7 @@
 
 require "rails"
 require "decidim/core"
+require "deface"
 
 module Decidim
   module Gallery

--- a/lib/decidim/gallery/engine.rb
+++ b/lib/decidim/gallery/engine.rb
@@ -2,6 +2,7 @@
 
 require "rails"
 require "decidim/core"
+require "nokogiri"
 require "deface"
 
 module Decidim

--- a/lib/decidim/gallery/engine.rb
+++ b/lib/decidim/gallery/engine.rb
@@ -2,8 +2,6 @@
 
 require "rails"
 require "decidim/core"
-require "nokogiri"
-require "deface"
 
 module Decidim
   module Gallery

--- a/lib/decidim/gallery/engine.rb
+++ b/lib/decidim/gallery/engine.rb
@@ -15,11 +15,11 @@ module Decidim
         root to: "gallery#index"
       end
 
-      initializer "decidim_gallery.deface" do
-        Rails.application.configure do
-          config.deface.enabled = true
-        end
-      end
+      #initializer "decidim_gallery.deface" do
+      #  Rails.application.configure do
+      #    config.deface.enabled = true
+      #  end
+      #end
 
       initializer "decidim_gallery.webpacker.assets_path" do
         Decidim.register_assets_path File.expand_path("app/packs", root)


### PR DESCRIPTION
#### Description

Engine's deface initializer might break the Docker image build. 

Without deface enabled, feature seems to work as expected