### PR TITLE
fix: Move the helper loading

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -50,7 +50,7 @@ jobs:
           SIMPLECOV: 0
           CODECOV: 0
 
-      - uses: actions/upload-artifact@v2-preview
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: screenshots

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
           SIMPLECOV: 1
           CODECOV: 1
 
-      - uses: actions/upload-artifact@v2-preview
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: screenshots

--- a/lib/decidim/gallery/engine.rb
+++ b/lib/decidim/gallery/engine.rb
@@ -15,11 +15,11 @@ module Decidim
         root to: "gallery#index"
       end
 
-      #initializer "decidim_gallery.deface" do
+      # initializer "decidim_gallery.deface" do
       #  Rails.application.configure do
       #    config.deface.enabled = true
       #  end
-      #end
+      # end
 
       initializer "decidim_gallery.webpacker.assets_path" do
         Decidim.register_assets_path File.expand_path("app/packs", root)

--- a/lib/decidim/gallery/engine.rb
+++ b/lib/decidim/gallery/engine.rb
@@ -33,11 +33,14 @@ module Decidim
       initializer "decidim_gallery.action_controller" do
         Rails.application.reloader.to_prepare do
           ActiveSupport.on_load :action_controller do
-            ::Decidim::Admin::StaticPagesController.helper Decidim::Gallery::Admin::ApplicationHelper
             ::Decidim::Admin::StaticPageForm.prepend Decidim::Gallery::Admin::StaticPages::Form
             ::Decidim::Admin::CreateStaticPage.prepend Decidim::Gallery::Admin::StaticPages::Command
             ::Decidim::Admin::UpdateStaticPage.prepend Decidim::Gallery::Admin::StaticPages::Command
           end
+        end
+
+        config.after_initialize do
+          ::Decidim::Admin::StaticPagesController.helper Decidim::Gallery::Admin::ApplicationHelper
         end
       end
 


### PR DESCRIPTION
We moved the helper loading method out of `to_prepare` because it was loading the helper before the application was fully initialized. This caused issues when `Decidim::Controller` was not yet loaded, leading to application crashes.  

We identified this issue after removing an `extends` linked to the `AccountController`. Previously, this `extends` ensured, with some reasons that we ignore for now, that `Decidim::Controller` was initialized in the correct order, allowing the application to function properly after the loading of the gallery module.  

Once we removed this now unnecessary `extends`, we encountered a crash that completely prevented the application from starting.
